### PR TITLE
Use `extra-doc-files` for documentation in `cabal` file.

### DIFF
--- a/quickcheck-groups.cabal
+++ b/quickcheck-groups.cabal
@@ -14,7 +14,7 @@ description:
   QuickCheck support for testing instances of type classes defined in the
   groups library.
 
-extra-source-files:
+extra-doc-files:
     CHANGELOG.md
     README.md
 


### PR DESCRIPTION
Fixes #32.